### PR TITLE
fix: coerce language array to string before withLocale()

### DIFF
--- a/src/Http/Controllers/GeocodingController.php
+++ b/src/Http/Controllers/GeocodingController.php
@@ -21,7 +21,7 @@ class GeocodingController
     {
         $query = $request->input('query');
         $countries = $request->input('countries', []);
-        $language = $request->input('language');
+        $language = $this->normalizeLanguage($request->input('language'));
 
         try {
             $geocodeQuery = GeocodeQuery::create($query);
@@ -48,7 +48,7 @@ class GeocodingController
     {
         $lat = $request->input('lat');
         $lon = $request->input('lon');
-        $language = $request->input('language');
+        $language = $this->normalizeLanguage($request->input('language'));
 
         try {
             $coordinates = new Coordinates((float) $lat, (float) $lon);
@@ -66,6 +66,22 @@ class GeocodingController
         } catch (\Exception $e) {
             return $this->handleGeocodingError($e);
         }
+    }
+
+    /**
+     * Normalize the incoming language value to an RFC2616-style string.
+     *
+     * The `language` fieldtype config is a taggable field, so the frontend
+     * can POST an array (e.g. ['en', 'de']). Geocoder's withLocale() is
+     * strictly typed as string, so we collapse arrays to a comma-separated list.
+     */
+    private function normalizeLanguage(mixed $language): ?string
+    {
+        if (is_array($language)) {
+            return implode(',', $language) ?: null;
+        }
+
+        return $language;
     }
 
     private function handleGeocodingError(\Exception $e): JsonResponse


### PR DESCRIPTION
## Problem

When the `language` config is set on a `simple_address` field in a blueprint (e.g. `language: [en]`), typing into the address input triggers:

```
TypeError: Geocoder\Query\GeocodeQuery::withLocale(): Argument #1 ($locale) must be of type string, array given
```

at `GeocodingController@search` line 34 (and the same pattern at line 58 in `reverse`).

## Root cause

The fieldtype's `language` config uses a `taggable` field, so `props.config.language` is an array. The Vue component POSTs it as-is:

```js
language: props.config.language || 'en',
```

The controller then passes it straight to `GeocodeQuery::withLocale()` / `ReverseQuery::withLocale()`, which are strictly typed `string`.

## Why it hasn't been caught

The bug only surfaces when `language` is explicitly present in the saved blueprint. Leaving the fieldtype unconfigured falls back to the frontend's `|| 'en'` string, which is what most users hit.

## Fix

Normalize the incoming `language` value to an RFC2616-style comma-separated string before handing it to Geocoder. This matches the format the fieldtype config instructions already advertise ("a standard RFC2616 ... or a simple comma-separated list of language codes").

- Empty arrays become `null` so the existing `if ($language)` guard continues to skip `withLocale`.
- String input is passed through unchanged, preserving current behavior for unset/default configs.

## Verification

Reproduced locally in a v6 sandbox with a blueprint containing `language: [en]`. Before: TypeError on every keystroke. After: Nominatim returns results normally. Unit-tested the helper via tinker:

```
normalizeLanguage(['en', 'de']) => 'en,de'
normalizeLanguage('en')         => 'en'
normalizeLanguage(null)         => null
normalizeLanguage([])           => null
```

## Backport

Same bug exists verbatim on `v0.2.x` (v5 line). Happy to open a backport PR once this is reviewed.