### PR TITLE
fix: cache serializable geocoder results

### DIFF
--- a/src/Services/GeocodingService.php
+++ b/src/Services/GeocodingService.php
@@ -2,6 +2,7 @@
 
 namespace ElSchneider\StatamicSimpleAddress\Services;
 
+use Geocoder\Provider\Cache\ProviderCache;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\ReverseQuery;
 use Geocoder\StatefulGeocoder;
@@ -20,9 +21,9 @@ class GeocodingService
 
         // Wrap with caching if enabled
         if (config('simple-address.cache.enabled')) {
-            $provider = new SerializableGeocoderCache(
+            $provider = new ProviderCache(
                 $provider,
-                app('cache')->store(config('simple-address.cache.store')),
+                new SerializableGeocoderCache(app('cache')->store(config('simple-address.cache.store'))),
                 config('simple-address.cache.duration')
             );
         }

--- a/src/Services/GeocodingService.php
+++ b/src/Services/GeocodingService.php
@@ -2,7 +2,6 @@
 
 namespace ElSchneider\StatamicSimpleAddress\Services;
 
-use Geocoder\Provider\Cache\ProviderCache;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\ReverseQuery;
 use Geocoder\StatefulGeocoder;
@@ -21,7 +20,7 @@ class GeocodingService
 
         // Wrap with caching if enabled
         if (config('simple-address.cache.enabled')) {
-            $provider = new ProviderCache(
+            $provider = new SerializableGeocoderCache(
                 $provider,
                 app('cache')->store(config('simple-address.cache.store')),
                 config('simple-address.cache.duration')

--- a/src/Services/SerializableGeocoderCache.php
+++ b/src/Services/SerializableGeocoderCache.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace ElSchneider\StatamicSimpleAddress\Services;
+
+use Geocoder\Collection;
+use Geocoder\Model\Address;
+use Geocoder\Model\AddressCollection;
+use Geocoder\Provider\Provider;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\ReverseQuery;
+use Psr\SimpleCache\CacheInterface;
+
+class SerializableGeocoderCache implements Provider
+{
+    private const CACHE_VERSION = 1;
+
+    public function __construct(
+        private Provider $provider,
+        private CacheInterface $cache,
+        private ?int $lifetime = null,
+        private bool $separateCache = false,
+    ) {}
+
+    public function geocodeQuery(GeocodeQuery $query): Collection
+    {
+        return $this->remember($this->cacheKey($query), fn () => $this->provider->geocodeQuery($query));
+    }
+
+    public function reverseQuery(ReverseQuery $query): Collection
+    {
+        return $this->remember($this->cacheKey($query), fn () => $this->provider->reverseQuery($query));
+    }
+
+    public function getName(): string
+    {
+        return sprintf('%s (cache)', $this->provider->getName());
+    }
+
+    public function __call(string $method, array $args): mixed
+    {
+        return call_user_func_array([$this->provider, $method], $args);
+    }
+
+    private function remember(string $key, callable $callback): Collection
+    {
+        $cached = $this->cache->get($key);
+
+        if ($cached = $this->restore($cached)) {
+            return $cached;
+        }
+
+        $result = $callback();
+
+        $this->cache->set($key, $this->normalize($result), $this->lifetime);
+
+        return $result;
+    }
+
+    private function cacheKey(GeocodeQuery|ReverseQuery $query): string
+    {
+        return 'ssa-geocoder-v'.self::CACHE_VERSION.sha1((string) $query.($this->separateCache ? $this->provider->getName() : ''));
+    }
+
+    private function normalize(Collection $collection): array
+    {
+        return [
+            'version' => self::CACHE_VERSION,
+            'locations' => array_map(fn ($location) => $location->toArray(), $collection->all()),
+        ];
+    }
+
+    private function restore(mixed $cached): ?Collection
+    {
+        if (! is_array($cached) || ($cached['version'] ?? null) !== self::CACHE_VERSION || ! is_array($cached['locations'] ?? null)) {
+            return null;
+        }
+
+        $locations = [];
+
+        foreach ($cached['locations'] as $location) {
+            if (! is_array($location)) {
+                return null;
+            }
+
+            $locations[] = Address::createFromArray($location);
+        }
+
+        return new AddressCollection($locations);
+    }
+}

--- a/src/Services/SerializableGeocoderCache.php
+++ b/src/Services/SerializableGeocoderCache.php
@@ -2,70 +2,83 @@
 
 namespace ElSchneider\StatamicSimpleAddress\Services;
 
+use DateInterval;
 use Geocoder\Collection;
 use Geocoder\Model\Address;
 use Geocoder\Model\AddressCollection;
-use Geocoder\Provider\Provider;
-use Geocoder\Query\GeocodeQuery;
-use Geocoder\Query\ReverseQuery;
 use Psr\SimpleCache\CacheInterface;
 
-class SerializableGeocoderCache implements Provider
+class SerializableGeocoderCache implements CacheInterface
 {
     private const CACHE_VERSION = 1;
 
     public function __construct(
-        private Provider $provider,
         private CacheInterface $cache,
-        private ?int $lifetime = null,
-        private bool $separateCache = false,
     ) {}
 
-    public function geocodeQuery(GeocodeQuery $query): Collection
+    public function get(string $key, mixed $default = null): mixed
     {
-        return $this->remember($this->cacheKey($query), fn () => $this->provider->geocodeQuery($query));
+        return $this->restore($this->cache->get($key)) ?? $default;
     }
 
-    public function reverseQuery(ReverseQuery $query): Collection
+    public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool
     {
-        return $this->remember($this->cacheKey($query), fn () => $this->provider->reverseQuery($query));
+        return $this->cache->set($key, $this->normalize($value), $ttl);
     }
 
-    public function getName(): string
+    public function delete(string $key): bool
     {
-        return sprintf('%s (cache)', $this->provider->getName());
+        return $this->cache->delete($key);
     }
 
-    public function __call(string $method, array $args): mixed
+    public function clear(): bool
     {
-        return call_user_func_array([$this->provider, $method], $args);
+        return $this->cache->clear();
     }
 
-    private function remember(string $key, callable $callback): Collection
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
-        $cached = $this->cache->get($key);
+        foreach ($keys as $key) {
+            yield $key => $this->get($key, $default);
+        }
+    }
 
-        if ($cached = $this->restore($cached)) {
-            return $cached;
+    public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            if (! $this->set($key, $value, $ttl)) {
+                return false;
+            }
         }
 
-        $result = $callback();
-
-        $this->cache->set($key, $this->normalize($result), $this->lifetime);
-
-        return $result;
+        return true;
     }
 
-    private function cacheKey(GeocodeQuery|ReverseQuery $query): string
+    public function deleteMultiple(iterable $keys): bool
     {
-        return 'ssa-geocoder-v'.self::CACHE_VERSION.sha1((string) $query.($this->separateCache ? $this->provider->getName() : ''));
+        foreach ($keys as $key) {
+            if (! $this->delete($key)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
-    private function normalize(Collection $collection): array
+    public function has(string $key): bool
     {
+        return $this->cache->has($key);
+    }
+
+    private function normalize(mixed $value): mixed
+    {
+        if (! $value instanceof Collection) {
+            return $value;
+        }
+
         return [
             'version' => self::CACHE_VERSION,
-            'locations' => array_map(fn ($location) => $location->toArray(), $collection->all()),
+            'locations' => array_map(fn ($location) => $location->toArray(), $value->all()),
         ];
     }
 

--- a/tests/Stubs/GoogleLikeProvider.php
+++ b/tests/Stubs/GoogleLikeProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Stubs;
+
+use Geocoder\Collection;
+use Geocoder\Model\Address;
+use Geocoder\Model\AddressCollection;
+use Geocoder\Model\AdminLevel;
+use Geocoder\Model\AdminLevelCollection;
+use Geocoder\Model\Coordinates;
+use Geocoder\Model\Country;
+use Geocoder\Provider\Provider;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\Query\ReverseQuery;
+
+class GoogleLikeProvider implements Provider
+{
+    public static int $calls = 0;
+
+    public function geocodeQuery(GeocodeQuery $query): Collection
+    {
+        self::$calls++;
+
+        return new AddressCollection([
+            new Address(
+                providedBy: 'google_maps',
+                adminLevels: new AdminLevelCollection([
+                    new AdminLevel(1, 'Baden-Württemberg', 'BW'),
+                    new AdminLevel(2, 'Tübingen', 'TÜ'),
+                ]),
+                coordinates: new Coordinates(48.5216, 9.0576),
+                streetNumber: '1',
+                streetName: 'Holzmarkt',
+                postalCode: '72070',
+                locality: 'Tübingen',
+                country: new Country('Germany', 'DE'),
+            ),
+        ]);
+    }
+
+    public function reverseQuery(ReverseQuery $query): Collection
+    {
+        self::$calls++;
+
+        return new AddressCollection([
+            Address::createFromArray([
+                'providedBy' => 'google_maps',
+                'latitude' => $query->getCoordinates()->getLatitude(),
+                'longitude' => $query->getCoordinates()->getLongitude(),
+                'locality' => 'Tübingen',
+                'country' => 'Germany',
+                'countryCode' => 'DE',
+            ]),
+        ]);
+    }
+
+    public function getName(): string
+    {
+        return 'google_maps';
+    }
+}

--- a/tests/Stubs/RestrictedUnserializeCache.php
+++ b/tests/Stubs/RestrictedUnserializeCache.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Stubs;
+
+use DateInterval;
+use Psr\SimpleCache\CacheInterface;
+
+class RestrictedUnserializeCache implements CacheInterface
+{
+    /** @var array<string, string> */
+    public array $items = [];
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        if (! array_key_exists($key, $this->items)) {
+            return $default;
+        }
+
+        return unserialize($this->items[$key], ['allowed_classes' => false]);
+    }
+
+    public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool
+    {
+        $this->items[$key] = serialize($value);
+
+        return true;
+    }
+
+    public function delete(string $key): bool
+    {
+        unset($this->items[$key]);
+
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        $this->items = [];
+
+        return true;
+    }
+
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        foreach ($keys as $key) {
+            yield $key => $this->get($key, $default);
+        }
+    }
+
+    public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+
+        return true;
+    }
+
+    public function deleteMultiple(iterable $keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->items);
+    }
+}

--- a/tests/Unit/Services/GeocodingServiceTest.php
+++ b/tests/Unit/Services/GeocodingServiceTest.php
@@ -4,6 +4,7 @@ use ElSchneider\StatamicSimpleAddress\ServiceProvider;
 use ElSchneider\StatamicSimpleAddress\Services\GeocodingService;
 use ElSchneider\StatamicSimpleAddress\Services\SerializableGeocoderCache;
 use Geocoder\Model\AddressCollection;
+use Geocoder\Provider\Cache\ProviderCache;
 use Geocoder\Query\GeocodeQuery;
 use Tests\Stubs\GoogleLikeProvider;
 use Tests\Stubs\RestrictedUnserializeCache;
@@ -47,7 +48,7 @@ test('that the geocoding service is bound as singleton', function () {
 test('geocoder cache stores scalar arrays that survive restricted unserialization', function () {
     GoogleLikeProvider::$calls = 0;
     $cache = new RestrictedUnserializeCache;
-    $provider = new SerializableGeocoderCache(new GoogleLikeProvider, $cache, 3600);
+    $provider = new ProviderCache(new GoogleLikeProvider, new SerializableGeocoderCache($cache), 3600);
     $query = GeocodeQuery::create('Holzmarkt 1, Tübingen');
 
     $first = $provider->geocodeQuery($query);

--- a/tests/Unit/Services/GeocodingServiceTest.php
+++ b/tests/Unit/Services/GeocodingServiceTest.php
@@ -2,6 +2,11 @@
 
 use ElSchneider\StatamicSimpleAddress\ServiceProvider;
 use ElSchneider\StatamicSimpleAddress\Services\GeocodingService;
+use ElSchneider\StatamicSimpleAddress\Services\SerializableGeocoderCache;
+use Geocoder\Model\AddressCollection;
+use Geocoder\Query\GeocodeQuery;
+use Tests\Stubs\GoogleLikeProvider;
+use Tests\Stubs\RestrictedUnserializeCache;
 
 test('that an error is thrown if the provider is not configured', function () {
     config(['simple-address.provider' => 'nonexistent']);
@@ -37,4 +42,47 @@ test('that the geocoding service is bound as singleton', function () {
     $service2 = app()->make(GeocodingService::class);
 
     expect($service1)->toBe($service2);
+});
+
+test('geocoder cache stores scalar arrays that survive restricted unserialization', function () {
+    GoogleLikeProvider::$calls = 0;
+    $cache = new RestrictedUnserializeCache;
+    $provider = new SerializableGeocoderCache(new GoogleLikeProvider, $cache, 3600);
+    $query = GeocodeQuery::create('Holzmarkt 1, Tübingen');
+
+    $first = $provider->geocodeQuery($query);
+    $second = $provider->geocodeQuery($query);
+
+    expect(GoogleLikeProvider::$calls)->toBe(1)
+        ->and($first)->toBeInstanceOf(AddressCollection::class)
+        ->and($second)->toBeInstanceOf(AddressCollection::class)
+        ->and($second->first()->getProvidedBy())->toBe('google_maps')
+        ->and($second->first()->getLocality())->toBe('Tübingen')
+        ->and(implode('', $cache->items))->not->toContain('Geocoder\\Model');
+});
+
+test('geocoding service uses safe cache with google-like provider when object serialization is restricted', function () {
+    GoogleLikeProvider::$calls = 0;
+
+    config([
+        'simple-address.provider' => 'google_like',
+        'simple-address.providers.google_like' => [
+            'class' => GoogleLikeProvider::class,
+        ],
+        'simple-address.cache.enabled' => true,
+        'simple-address.cache.store' => 'restricted_unserialize',
+        'cache.stores.restricted_unserialize' => ['driver' => 'restricted_unserialize'],
+    ]);
+
+    app('cache')->extend('restricted_unserialize', fn () => new RestrictedUnserializeCache);
+    app()->forgetInstance(GeocodingService::class);
+
+    $service = new GeocodingService;
+
+    $first = $service->geocode(GeocodeQuery::create('Holzmarkt 1, Tübingen'));
+    $second = $service->geocode(GeocodeQuery::create('Holzmarkt 1, Tübingen'));
+
+    expect(GoogleLikeProvider::$calls)->toBe(1)
+        ->and($first[0]->getProvidedBy())->toBe('google_maps')
+        ->and($second[0]->getLocality())->toBe('Tübingen');
 });


### PR DESCRIPTION
## Summary
- Closes https://github.com/el-schneider/statamic-simple-address/issues/19.
- Fixes the Laravel 13 cache failure when `serializable_classes=false` prevents unserializing geocoder provider result objects from cache.
- Keeps geocoder-php's upstream `ProviderCache` for cache key/orchestration behavior, and wraps the Laravel cache store with `SerializableGeocoderCache` so cached geocoder collections are stored as plain arrays and rehydrated on read.
- Keeps the change scoped to the geocoding cache path so providers continue to return normal geocoder result objects to the rest of the package.

## Tests and validation
- Added unit coverage for the safe cache adapter using a restricted-unserialize cache stub and a Google-like provider result shape.
- `./vendor/bin/pint --test`
- `./vendor/bin/pest --exclude-group=browser`
- Validated in a Laravel 13 sandbox with cache `serializable_classes=false`.
- Validated via Chrome DevTools against the Statamic control panel using Nominatim and a real Google Maps provider; repeated searches returned from cache without serialized `Geocoder\\Model` / Google provider objects in the payload.
