### PR TITLE
feat: add expand_details option to open the details panel by default

### DIFF
--- a/resources/js/address-field.vue
+++ b/resources/js/address-field.vue
@@ -58,7 +58,8 @@ const { $axios, $toast, cp_url } = getCurrentInstance().appContext.config.global
 
 // State
 const options = ref([])
-const showDetails = ref(false)
+const expandDetails = computed(() => props.config.expand_details ?? false)
+const showDetails = ref(expandDetails.value)
 const detailsPanel = ref(null)
 
 // Debounce helper
@@ -89,13 +90,13 @@ const selectedKey = computed({
   set: (key) => {
     if (!key) {
       update(null)
-      showDetails.value = false
+      showDetails.value = expandDetails.value
       return
     }
     const selected = options.value.find((opt) => opt.value === key)
     if (selected) {
       update(selected.address)
-      showDetails.value = false
+      showDetails.value = expandDetails.value
     }
   },
 })

--- a/src/Fieldtypes/SimpleAddress.php
+++ b/src/Fieldtypes/SimpleAddress.php
@@ -34,6 +34,12 @@ class SimpleAddress extends Fieldtype
                 'display' => __('Exclude Fields'),
                 'instructions' => __('Fields to exclude from the address result. (e.g. **bounds**, **adminLevels**, **providedBy**)'),
             ],
+            'expand_details' => [
+                'type' => 'toggle',
+                'display' => __('Expand details by default'),
+                'instructions' => __('Show the map and address details right away, instead of behind the "Show details" button.'),
+                'default' => false,
+            ],
         ];
     }
 

--- a/tests/Browser/SimpleAddressFieldtypeTest.php
+++ b/tests/Browser/SimpleAddressFieldtypeTest.php
@@ -5,6 +5,102 @@ use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\User;
 
+/**
+ * Creates a super user, a collection whose blueprint holds a single simple_address
+ * field with the given config, and one entry. The entry is seeded with a real
+ * search result so the value shape matches what the fieldtype actually stores.
+ *
+ * Returns the control panel edit URL of that entry.
+ */
+function seedAddressEntry(object $test, string $collectionHandle, array $fieldConfig = [], bool $withValue = true): string
+{
+    $user = User::make()
+        ->email("admin+{$collectionHandle}@test.com")
+        ->password('password')
+        ->makeSuper();
+
+    $user->save();
+
+    Collection::make($collectionHandle)
+        ->title(ucfirst($collectionHandle))
+        ->save();
+
+    Blueprint::makeFromFields([
+        'address' => array_merge(['type' => 'simple_address'], $fieldConfig),
+    ])
+        ->setHandle('default')
+        ->setNamespace('collections/'.$collectionHandle)
+        ->save();
+
+    $test->actingAs($user);
+
+    $data = ['title' => 'First'];
+
+    if ($withValue) {
+        $data['address'] = $test->post('/cp/simple-address/search', ['query' => '123 Main'])
+            ->assertOk()
+            ->json('results.0');
+    }
+
+    $entry = Entry::make()
+        ->collection($collectionHandle)
+        ->slug('first')
+        ->published(true)
+        ->data($data);
+
+    $entry->save();
+
+    return "/cp/collections/{$collectionHandle}/entries/{$entry->id()}";
+}
+
+it('keeps the details panel collapsed when expand_details is off', function () {
+    $editUrl = seedAddressEntry($this, 'collapsed');
+
+    visit($editUrl)
+        ->assertPresent('.simple-address-field')
+        ->assertSee('Show details')
+        ->assertDontSee('Hide details');
+});
+
+it('shows the details panel right away when expand_details is on', function () {
+    $editUrl = seedAddressEntry($this, 'expanded', ['expand_details' => true]);
+
+    visit($editUrl)
+        ->assertPresent('.simple-address-field')
+        ->assertSee('Hide details')
+        ->assertPresent('.leaflet-container');
+});
+
+it('leaves the details panel open when the address is replaced', function () {
+    $editUrl = seedAddressEntry($this, 'replaced', ['expand_details' => true], withValue: false);
+
+    $input = '.simple-address-field input[type="search"]';
+
+    visit($editUrl)
+        // Without a value there is no toggle and no panel at all.
+        ->assertDontSee('Hide details')
+        ->click($input)
+        ->typeSlowly($input, '123 Main', 50)
+        ->assertScript('(async () => {
+            const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+            for (let i = 0; i < 40; i++) {
+                const items = Array.from(document.querySelectorAll("[data-ui-combobox-item]"));
+
+                if (items.some((el) => (el.textContent || "").includes("Main Street"))) {
+                    return true;
+                }
+
+                await delay(250);
+            }
+
+            return false;
+        })()', true)
+        ->click('internal:text="123, Main Street, London, England, United Kingdom"i')
+        ->assertSee('Hide details')
+        ->assertPresent('.leaflet-container');
+});
+
 it('lets you search and save a simple address in the control panel', function () {
     $user = User::make()
         ->email('admin@test.com')


### PR DESCRIPTION
## What

Adds an optional **Expand details by default** toggle to the fieldtype config. When enabled, `AddressDetailsPanel` (map + YAML) is visible as soon as an address is selected, instead of hidden behind the *Show details* button.

Defaults to `false`, so existing fields keep their current behaviour.

## Why

We are moving an events collection from another address addon to this one. Editors there mostly use the map to sanity-check or nudge the marker after picking a result, so the extra click on every entry adds up. Making it configurable seemed more useful than changing the default for everyone.

## How

- `SimpleAddress::configFieldItems()`: new `expand_details` toggle, default `false`
- `address-field.vue`: `showDetails` initialises from `props.config.expand_details` and returns to that value when the selection changes, rather than always collapsing

## Notes

- `resources/dist/` is intentionally not part of this PR, per AGENTS.md (built by CI). Verified locally with a build against Statamic 6.20.
- No test added. The existing browser tests do not cover the details panel yet, so there was no obvious place to extend. Happy to add one if you point me at the shape you would want.
- `prettier --check` and `eslint` pass on the changed file.