### PR TITLE
feat: add expand_details and zoom fieldtype options

### DIFF
--- a/resources/js/address-field.vue
+++ b/resources/js/address-field.vue
@@ -59,8 +59,8 @@ const { $axios, $toast, cp_url } = getCurrentInstance().appContext.config.global
 
 // State
 const options = ref([])
-const expandDetails = computed(() => props.config.expand_details ?? false)
-const showDetails = ref(expandDetails.value)
+const expandDetails = props.config.expand_details ?? false
+const showDetails = ref(expandDetails)
 const detailsPanel = ref(null)
 
 // Debounce helper
@@ -91,13 +91,13 @@ const selectedKey = computed({
   set: (key) => {
     if (!key) {
       update(null)
-      showDetails.value = expandDetails.value
+      showDetails.value = expandDetails
       return
     }
     const selected = options.value.find((opt) => opt.value === key)
     if (selected) {
       update(selected.address)
-      showDetails.value = expandDetails.value
+      showDetails.value = expandDetails
     }
   },
 })

--- a/resources/js/address-field.vue
+++ b/resources/js/address-field.vue
@@ -58,7 +58,8 @@ const { $axios, $toast, cp_url } = getCurrentInstance().appContext.config.global
 
 // State
 const options = ref([])
-const showDetails = ref(false)
+const expandDetails = computed(() => props.config.expand_details ?? false)
+const showDetails = ref(expandDetails.value)
 const detailsPanel = ref(null)
 
 // Debounce helper
@@ -89,13 +90,13 @@ const selectedKey = computed({
   set: (key) => {
     if (!key) {
       update(null)
-      showDetails.value = false
+      showDetails.value = expandDetails.value
       return
     }
     const selected = options.value.find((opt) => opt.value === key)
     if (selected) {
       update(selected.address)
-      showDetails.value = false
+      showDetails.value = expandDetails.value
     }
   },
 })

--- a/resources/js/address-field.vue
+++ b/resources/js/address-field.vue
@@ -36,6 +36,7 @@
       v-if="showDetails && value"
       ref="detailsPanel"
       :address="value"
+      :zoom="config.zoom"
       @coordinates-changed="onCoordinatesChanged"
     />
   </div>

--- a/resources/js/components/AddressDetailsPanel.vue
+++ b/resources/js/components/AddressDetailsPanel.vue
@@ -21,9 +21,11 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  // null, not 13: an unset Statamic integer arrives as null, so the fallback
+  // has to live in zoomLevel anyway. Keeping it in one place.
   zoom: {
     type: [Number, String],
-    default: 13,
+    default: null,
   },
 })
 
@@ -35,12 +37,11 @@ const marker = ref(null)
 const originalPosition = ref(null)
 const mouseCoords = ref(null)
 
-// Vue's prop default only covers undefined, but Statamic hands over an unset
-// integer as null. Zoom 0 is a valid Leaflet level, so it must survive the check.
+// parseFloat, not Number: Number(null) is 0 and zoom 0 is a valid Leaflet level.
 const zoomLevel = computed(() => {
-  const zoom = Number(props.zoom)
+  const zoom = parseFloat(props.zoom)
 
-  return props.zoom === null || props.zoom === '' || !Number.isFinite(zoom) ? 13 : zoom
+  return Number.isNaN(zoom) ? 13 : zoom
 })
 
 const formattedYaml = computed(() => formatAsYaml(props.address))

--- a/resources/js/components/AddressDetailsPanel.vue
+++ b/resources/js/components/AddressDetailsPanel.vue
@@ -21,6 +21,10 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  zoom: {
+    type: [Number, String],
+    default: 13,
+  },
 })
 
 const emit = defineEmits(['coordinates-changed'])
@@ -30,6 +34,14 @@ const map = ref(null)
 const marker = ref(null)
 const originalPosition = ref(null)
 const mouseCoords = ref(null)
+
+// Vue's prop default only covers undefined, but Statamic hands over an unset
+// integer as null. Zoom 0 is a valid Leaflet level, so it must survive the check.
+const zoomLevel = computed(() => {
+  const zoom = Number(props.zoom)
+
+  return props.zoom === null || props.zoom === '' || !Number.isFinite(zoom) ? 13 : zoom
+})
 
 const formattedYaml = computed(() => formatAsYaml(props.address))
 const colorMode = computed(() => Statamic.$colorMode.mode.value)
@@ -49,7 +61,7 @@ function initializeMap() {
     return
   }
 
-  map.value = L.map(mapContainer.value).setView([parseFloat(lat), parseFloat(lon)], 13)
+  map.value = L.map(mapContainer.value).setView([parseFloat(lat), parseFloat(lon)], zoomLevel.value)
 
   map.value.zoomControl.remove()
   L.control.zoom({ position: 'bottomright' }).addTo(map.value)

--- a/src/Fieldtypes/SimpleAddress.php
+++ b/src/Fieldtypes/SimpleAddress.php
@@ -34,6 +34,12 @@ class SimpleAddress extends Fieldtype
                 'display' => __('Exclude Fields'),
                 'instructions' => __('Fields to exclude from the address result. (e.g. **bounds**, **adminLevels**, **providedBy**)'),
             ],
+            'expand_details' => [
+                'type' => 'toggle',
+                'display' => __('Expand details by default'),
+                'instructions' => __('Show the map and address details right away, instead of behind the "Show details" button.'),
+                'default' => false,
+            ],
         ];
     }
 

--- a/src/Fieldtypes/SimpleAddress.php
+++ b/src/Fieldtypes/SimpleAddress.php
@@ -34,6 +34,14 @@ class SimpleAddress extends Fieldtype
                 'display' => __('Exclude Fields'),
                 'instructions' => __('Fields to exclude from the address result. (e.g. **bounds**, **adminLevels**, **providedBy**)'),
             ],
+            'zoom' => [
+                'type' => 'integer',
+                'display' => __('Map Zoom'),
+                'instructions' => __('Initial zoom level of the map. Leaflet scale from **0** (the whole world) to **20**, roughly **10** for a city, **13** for a district, **17** for a single building.'),
+                'width' => 50,
+                'default' => 13,
+                'validate' => ['integer', 'min:0', 'max:20'],
+            ],
             'expand_details' => [
                 'type' => 'toggle',
                 'display' => __('Expand details by default'),


### PR DESCRIPTION
Combines the two fieldtype options contributed in #21 and #22 into one branch, rebased on `main`.

Both changes are @eugene-karuna's work and are credited via `Co-authored-by` trailers.

## What

- **Expand details by default** — optional toggle, shows the map and YAML panel as soon as an address is selected instead of behind the *Show details* button. Defaults to `false`.
- **Map Zoom** — integer option for the initial zoom level, validated `0..20`. Defaults to `13`, the value that was previously hard-coded.

## Changes against the original PRs

- The zoom fallback is squashed into its final form. #22 shipped `Number(props.zoom) || 13`, which swallowed a configured zoom of `0`, then fixed it in a follow-up commit. This uses `parseFloat`, where `null` and `''` are already `NaN`, so one check replaces three.
- The `zoom` prop default is gone. It never fired: an unset Statamic integer arrives as `null`, not `undefined`, so the fallback belongs in `zoomLevel` alone rather than in two places.
- `expandDetails` is a plain const instead of a `computed`. Nothing observes its reactivity.

## No tests

CI runs `pest --ci --exclude-group=browser`, and everything under `tests/Browser/` is in that group, so the browser tests from both PRs would never have executed. What remains is a boolean pass-through and one fallback in a repo with no JS test runner. Covering the details panel properly means getting the browser group running in CI first, which is worth doing on its own.

## Verified

Manually in a Statamic 6 control panel, against three fields on one entry:

| Config | Panel on load | Rendered tile zoom |
| --- | --- | --- |
| none | collapsed | 13 after opening |
| `expand_details: true`, `zoom: 9` | open | 9 |
| `expand_details: true`, `zoom: 0` | open | 0 |

Also checked: selecting a new address keeps the panel open when configured and still collapses it when not, values survive a save round-trip, both options render in the field settings with their instructions, and `zoom: 25` is rejected with "May not be greater than 20".

`resources/dist/` is intentionally not included; `build-assets.yml` rebuilds it on push to `main`.

Closes #21
Closes #22
