### PR TITLE
fix: keep the map view when the marker is dragged

### DIFF
--- a/resources/js/address-field.vue
+++ b/resources/js/address-field.vue
@@ -151,7 +151,9 @@ async function onCoordinatesChanged({ lat, lon }) {
 
     const results = response.data.results || []
     if (results.length > 0) {
-      update(results[0])
+      // The lookup describes the nearest known place, but the point the user
+      // dropped is the one they meant. Keep their coordinates, take the label.
+      update({ ...results[0], lat, lon })
       $toast?.success(__('Address updated from map'))
     } else {
       update({ ...props.value, lat, lon })

--- a/resources/js/components/AddressDetailsPanel.vue
+++ b/resources/js/components/AddressDetailsPanel.vue
@@ -98,6 +98,35 @@ function initializeMap() {
   map.value.invalidateSize()
 }
 
+// Rebuilding the map on every address change reset the zoom while the user was
+// still working. Move the marker instead, and recenter only when the address
+// points somewhere the marker is not already sitting, which is any change other
+// than the echo of a drag.
+function syncToAddress() {
+  const { lat, lon } = props.address
+
+  if (!lat || !lon) {
+    return
+  }
+
+  if (!map.value) {
+    initializeMap()
+    return
+  }
+
+  const target = [parseFloat(lat), parseFloat(lon)]
+  // Coordinates round-trip through toFixed(7), so compare with a tolerance of
+  // roughly 10 cm rather than exactly.
+  const moved = !marker.value.getLatLng().equals(target, 1e-6)
+
+  marker.value.setLatLng(target)
+  originalPosition.value = target
+
+  if (moved) {
+    map.value.setView(target, zoomLevel.value)
+  }
+}
+
 function onMarkerDragEnd() {
   const newLatLng = marker.value.getLatLng()
   emit('coordinates-changed', {
@@ -139,11 +168,7 @@ defineExpose({
   revertMarkerPosition,
 })
 
-watch(
-  () => props.address,
-  () => initializeMap(),
-  { deep: true },
-)
+watch(() => props.address, syncToAddress, { deep: true })
 
 watch(
   () => colorMode.value,


### PR DESCRIPTION
Alternative to #24, same bug, smaller change. Credited to @eugene-karuna, whose PR found and diagnosed it.

## The bug

Every address change tore the map down and rebuilt it with `setView(coords, zoom)`. Dragging the marker triggers a reverse lookup that updates the address, so the map was rebuilt and the zoom reset mid-placement.

## The fix

The map stays alive. `syncToAddress()` moves the marker, and recenters only when the address points somewhere the marker is not already sitting — which is true for a search or a preset value, and false for the echo of a drag. No flag, no tracked pending state; the marker position already carries the answer.

While tracing it, a second bug surfaced: on a successful drag the panel stored `results[0]` from the reverse lookup, so the marker jumped from the dropped point to whatever the geocoder matched. Measured against Nominatim: 5 m in a city, 400 m in a village, 14.6 km in open alpine terrain. The lookup now supplies the label and the user's coordinates are kept, which is also what makes the recenter check work.

## Why not #24

#24 tracks a boolean from drag start until the address update arrives. Two problems, found independently by two reviewers:

- Selecting an address while the reverse lookup is still in flight consumes the flag, so the new selection does not recenter, and the late response then overwrites it.
- It keeps the geocoder's coordinates, so the marker still jumps away from the dropped point — and because the flag suppresses the recenter, it can land off-screen with nothing bringing the view back.

Deriving the answer from the marker position avoids both.

## Verified

In a Statamic 6 control panel, on a field configured with `zoom: 9`:

- Zoomed manually to 10, dragged the marker: view stayed at 10, marker stayed exactly at the drop point, label updated to the matched place.
- Selected a new address afterwards: recentered at the configured zoom 9.
- Fields configured with no zoom and with `zoom: 0` still open at 13 and 0.
- No console errors.

Known pre-existing issue, not addressed here: a reverse lookup that resolves after the user has picked a different address still overwrites that selection. It predates both PRs and wants request sequencing in the parent.
